### PR TITLE
Fixed incorrect next timeout calculation

### DIFF
--- a/libcurvecpr/include/curvecpr/block.h
+++ b/libcurvecpr/include/curvecpr/block.h
@@ -1,6 +1,10 @@
 #ifndef __CURVECPR_BLOCK_H
 #define __CURVECPR_BLOCK_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <string.h>
 
 #include <sodium/crypto_uint32.h>
@@ -29,5 +33,9 @@ struct curvecpr_block {
     size_t data_len;
     unsigned char data[1024];
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/bytes.h
+++ b/libcurvecpr/include/curvecpr/bytes.h
@@ -1,6 +1,10 @@
 #ifndef __LIBCURVECPR_BYTES_H
 #define __LIBCURVECPR_BYTES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <string.h>
 
 #include <sodium/crypto_uint16.h>
@@ -17,5 +21,9 @@ void curvecpr_bytes_pack_uint32 (unsigned char *destination, crypto_uint32 sourc
 crypto_uint32 curvecpr_bytes_unpack_uint32 (const unsigned char *source);
 void curvecpr_bytes_pack_uint64 (unsigned char *destination, crypto_uint64 source);
 crypto_uint64 curvecpr_bytes_unpack_uint64 (const unsigned char *source);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/chicago.h
+++ b/libcurvecpr/include/curvecpr/chicago.h
@@ -1,6 +1,10 @@
 #ifndef __CURVECPR_CHICAGO_H
 #define __CURVECPR_CHICAGO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct curvecpr_chicago {
     long long clock;
 
@@ -30,5 +34,9 @@ void curvecpr_chicago_new (struct curvecpr_chicago *chicago);
 void curvecpr_chicago_refresh_clock (struct curvecpr_chicago *chicago);
 void curvecpr_chicago_on_timeout (struct curvecpr_chicago *chicago);
 void curvecpr_chicago_on_recv (struct curvecpr_chicago *chicago, long long ns_sent);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/client.h
+++ b/libcurvecpr/include/curvecpr/client.h
@@ -1,6 +1,10 @@
 #ifndef __CURVECPR_CLIENT_H
 #define __CURVECPR_CLIENT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "session.h"
 
 #include <string.h>
@@ -49,5 +53,9 @@ void curvecpr_client_new (struct curvecpr_client *client, const struct curvecpr_
 int curvecpr_client_connected (struct curvecpr_client *client);
 int curvecpr_client_recv (struct curvecpr_client *client, const unsigned char *buf, size_t num);
 int curvecpr_client_send (struct curvecpr_client *client, const unsigned char *buf, size_t num);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/messager.h
+++ b/libcurvecpr/include/curvecpr/messager.h
@@ -1,6 +1,10 @@
 #ifndef __CURVECPR_MESSAGER_H
 #define __CURVECPR_MESSAGER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "block.h"
 #include "chicago.h"
 
@@ -70,5 +74,9 @@ void curvecpr_messager_new (struct curvecpr_messager *messager, const struct cur
 int curvecpr_messager_recv (struct curvecpr_messager *messager, const unsigned char *buf, size_t num);
 int curvecpr_messager_process_sendq (struct curvecpr_messager *messager);
 long long curvecpr_messager_next_timeout (struct curvecpr_messager *messager);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/packet.h
+++ b/libcurvecpr/include/curvecpr/packet.h
@@ -1,6 +1,10 @@
 #ifndef __CURVECPR_PACKET_H
 #define __CURVECPR_PACKET_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct curvecpr_packet_any {
     unsigned char id[8];
     unsigned char server_extension[16];
@@ -66,5 +70,9 @@ struct curvecpr_packet_client_message {
     unsigned char nonce[8];
     /* A boxed message will follow. */
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/server.h
+++ b/libcurvecpr/include/curvecpr/server.h
@@ -1,6 +1,10 @@
 #ifndef __CURVECPR_SERVER_H
 #define __CURVECPR_SERVER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "session.h"
 
 #include <string.h>
@@ -41,5 +45,9 @@ void curvecpr_server_new (struct curvecpr_server *server, const struct curvecpr_
 void curvecpr_server_refresh_temporal_keys (struct curvecpr_server *server);
 int curvecpr_server_recv (struct curvecpr_server *server, void *priv, const unsigned char *buf, size_t num, struct curvecpr_session **s_stored);
 int curvecpr_server_send (struct curvecpr_server *server, struct curvecpr_session *s, void *priv, const unsigned char *buf, size_t num);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/session.h
+++ b/libcurvecpr/include/curvecpr/session.h
@@ -1,6 +1,10 @@
 #ifndef __CURVECPR_SESSION_H
 #define __CURVECPR_SESSION_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <sodium/crypto_uint64.h>
 
 struct curvecpr_session {
@@ -36,5 +40,9 @@ struct curvecpr_session {
 void curvecpr_session_new (struct curvecpr_session *s);
 void curvecpr_session_next_nonce (struct curvecpr_session *s, unsigned char *destination);
 void curvecpr_session_set_priv (struct curvecpr_session *s, void *priv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/include/curvecpr/util.h
+++ b/libcurvecpr/include/curvecpr/util.h
@@ -1,8 +1,16 @@
 #ifndef __CURVECPR_UTIL_H
 #define __CURVECPR_UTIL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 long long curvecpr_util_random_mod_n (long long n);
 long long curvecpr_util_nanoseconds (void);
 int curvecpr_util_encode_domain_name (unsigned char *destination, const char *source);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libcurvecpr/lib/messager.c
+++ b/libcurvecpr/lib/messager.c
@@ -517,6 +517,11 @@ long long curvecpr_messager_next_timeout (struct curvecpr_messager *messager)
 
         if (at > block->clock + chicago->rtt_timeout)
             at = block->clock + chicago->rtt_timeout;
+
+        /* Writing faster than wr_rate does not make sense and will cause spinning. BUT, if
+           there is something to acknowledge, block might still be resent. */
+        if (cf->ops.recvmarkq_is_empty(messager) && at < messager->my_sent_clock + chicago->wr_rate)
+            at = messager->my_sent_clock + chicago->wr_rate;
     }
 
     if (chicago->clock > at)

--- a/libcurvecpr/lib/messager.c
+++ b/libcurvecpr/lib/messager.c
@@ -108,13 +108,8 @@ int curvecpr_messager_recv (struct curvecpr_messager *messager, const unsigned c
         /* Range 1. */
         start = 0;
         end = curvecpr_bytes_unpack_uint64(message->acknowledging_range_1_size);
-        if (start - end > 0) {
+        if (start - end > 0)
             cf->ops.sendmarkq_remove_range(messager, start, end);
-
-            /* If we're at EOF, see if we can move to a final state. */
-            if (messager->my_eof && end >= messager->my_sent_bytes)
-                messager->my_final = 1;
-        }
 
         /* Range 2. */
         start = end + (unsigned long long)curvecpr_bytes_unpack_uint32(message->acknowledging_range_12_gap);
@@ -145,6 +140,11 @@ int curvecpr_messager_recv (struct curvecpr_messager *messager, const unsigned c
         end = start + (unsigned long long)curvecpr_bytes_unpack_uint16(message->acknowledging_range_6_size);
         if (start - end > 0)
             cf->ops.sendmarkq_remove_range(messager, start, end);
+
+        /* If we're at EOF, see if we can move to a final state. */
+        struct curvecpr_block block;
+        if (messager->my_eof && cf->ops.sendmarkq_head(messager, &block) == -1)
+            messager->my_final = 1;
     }
 
     /* Read size and flags and dispatch data to delegate. */


### PR DESCRIPTION
Previously the next time interval could be set to RTT timeout for a block (when the block needs to be resent). But when this comes faster than the write rate computed by Chicago algorithm, such a premature sendq processing would cause spinning. So we allow a fast resend only when any acknowledgements are pending as ACKs may be sent together with blocks faster than the write rate.
