### PR TITLE
Use CLOCK_MONOTONIC instead of CLOCK_REALTIME

### DIFF
--- a/libcurvecpr/lib/util.c
+++ b/libcurvecpr/lib/util.c
@@ -61,7 +61,12 @@ long long curvecpr_util_nanoseconds (void)
 
     if (clock_get_time(cclock, &t) != KERN_SUCCESS)
         return -1;
-#else
+#elif defined(CLOCK_MONOTONIC)
+    struct timespec t;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &t) != 0)
+        return -1;
+#elif defined(CLOCK_REALTIME)
     struct timespec t;
 
     if (clock_gettime(CLOCK_REALTIME, &t) != 0)


### PR DESCRIPTION
This prevents problems when the clock is jumping around which can happen
when NTP starts or in a misconfigured environment with multiple NTP
servers that are out of sync.

Closes #14 
