### PR TITLE
Monotonic clock

### DIFF
--- a/libcurvecpr/lib/util.c
+++ b/libcurvecpr/lib/util.c
@@ -61,7 +61,12 @@ long long curvecpr_util_nanoseconds (void)
 
     if (clock_get_time(cclock, &t) != KERN_SUCCESS)
         return -1;
-#else
+#elif defined(CLOCK_MONOTONIC)
+    struct timespec t;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &t) != 0)
+        return -1;
+#elif defined(CLOCK_REALTIME)
     struct timespec t;
 
     if (clock_gettime(CLOCK_REALTIME, &t) != 0)

--- a/libcurvecpr/test/util/test_nanoseconds.c
+++ b/libcurvecpr/test/util/test_nanoseconds.c
@@ -8,14 +8,14 @@ START_TEST (test_nanoseconds)
     long long nanoseconds = curvecpr_util_nanoseconds();
 
     fail_if(nanoseconds < 0);
-    fail_unless(nanoseconds > 1374047000000000000LL);
+    fail_unless(nanoseconds > 0);
 
     /* On OS X, we may cache the kernel clock reference. Make sure it still
        works. */
-    nanoseconds = curvecpr_util_nanoseconds();
+    long long nanoseconds1 = curvecpr_util_nanoseconds();
 
-    fail_if(nanoseconds < 0);
-    fail_unless(nanoseconds > 1374047000000000000LL);
+    fail_if(nanoseconds1 < 0);
+    fail_unless(nanoseconds1 > nanoseconds);
 }
 END_TEST
 


### PR DESCRIPTION
Use a monotonic clock where possible, adjusted the test to take that into account.

Closes #15 
